### PR TITLE
fix: PendingIntend issues on Android v12+

### DIFF
--- a/org.eclipse.paho.android.service/src/main/java/org/eclipse/paho/android/service/AlarmPingSender.java
+++ b/org.eclipse.paho.android.service/src/main/java/org/eclipse/paho/android/service/AlarmPingSender.java
@@ -74,7 +74,7 @@ class AlarmPingSender implements MqttPingSender {
 		service.registerReceiver(alarmReceiver, new IntentFilter(action));
 
 		pendingIntent = PendingIntent.getBroadcast(service, 0, new Intent(
-				action), PendingIntent.FLAG_UPDATE_CURRENT);
+				action), PendingIntent.FLAG_IMMUTABLE);
 
 		schedule(comms.getKeepAlive());
 		hasStarted = true;


### PR DESCRIPTION
From Android v12 and above PendingIntends need to use the flag FLAG_IMMUTABLE or FLAG_MUTABLE (with a recommendation towards FLAG_IMMUTABLE).
